### PR TITLE
Working polyfill for console.exception instead of noop function

### DIFF
--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -1,5 +1,5 @@
 console.exception = function exception() {
-  if ("error" in console) {
-    console.error.apply(this, arguments);
-  }
+    if ("error" in console) {
+        Function.prototype.apply.call(console.error, null, arguments);
+    }
 };

--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -1,5 +1,5 @@
 console.exception = function exception() {
     if ("error" in console) {
-        Function.prototype.apply.call(console.error, null, arguments);
+        Function.prototype.apply.call(console.error, console, arguments);
     }
 };

--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -1,1 +1,1 @@
-console.exception = function exception() {};
+console.exception = 'error' in console ? console.error : function exception() {};

--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -2,4 +2,4 @@ console.exception = function exception() {
   if ("error" in console) {
     console.error.apply(this, arguments);
   }
-);
+};

--- a/polyfills/console/exception/polyfill.js
+++ b/polyfills/console/exception/polyfill.js
@@ -1,1 +1,5 @@
-console.exception = 'error' in console ? console.error : function exception() {};
+console.exception = function exception() {
+  if ("error" in console) {
+    console.error.apply(this, arguments);
+  }
+);


### PR DESCRIPTION
Provides working polyfill for ``console.exception`` instead of noop function

The thing is according to **[MDN Web APIs reference]( https://developer.mozilla.org/en-US/docs/Web/API/console)** ``console.exception`` is an obsolete alias for ``console.error`` method

So, if ``error`` exists in ``console``, we can provide it under ``console.exception`` name and thus get this polyfill working. If there's no ``error`` in ``console``, we're falling back to noop ``function exception() {}``