### PR TITLE
Drop Android 5.0 from test suite

### DIFF
--- a/test/polyfills/browsers.toml
+++ b/test/polyfills/browsers.toml
@@ -4,7 +4,6 @@ browsers = [
   # "android/11.0",
   # "android/12.0",
   # "android/13.0",
-  "android/5.0",
   # "android/6.0",
   # "android/7.0",
   # "android/7.1",

--- a/test/polyfills/browserstackBrowsers.toml
+++ b/test/polyfills/browserstackBrowsers.toml
@@ -21290,12 +21290,5 @@ real_mobile = true
 os = "android"
 os_version = "5.0"
 browser = "android"
-device = "Samsung Galaxy S6"
-real_mobile = true
-
-[[browsers]]
-os = "android"
-os_version = "5.0"
-browser = "android"
 device = "Motorola Moto X 2nd Gen"
 real_mobile = true

--- a/test/polyfills/browserstackBrowsers.toml
+++ b/test/polyfills/browserstackBrowsers.toml
@@ -21285,10 +21285,3 @@ os_version = "6.0"
 browser = "android"
 device = "Samsung Galaxy S7"
 real_mobile = true
-
-[[browsers]]
-os = "android"
-os_version = "5.0"
-browser = "android"
-device = "Motorola Moto X 2nd Gen"
-real_mobile = true


### PR DESCRIPTION
This PR drops all Android 5.0 devices from the BrowserStack browser list, since they have been removed by BrowserStack.